### PR TITLE
refactor: helper function and improve code quality

### DIFF
--- a/src/gta_api.c
+++ b/src/gta_api.c
@@ -781,9 +781,10 @@ GTA_DEFINE_FUNCTION(bool, gta_instance_final,
     return false;
 }
 
-static struct provider_list_item_t *
+static bool
 find_personality(gta_instance_handle_t h_inst,
     const gta_personality_name_t personality_name,
+    struct provider_list_item_t ** p_provider_list_item,
     gta_errinfo_t * p_errinfo);
 
 GTA_DEFINE_FUNCTION(gta_context_handle_t, gta_context_open,
@@ -799,9 +800,8 @@ GTA_DEFINE_FUNCTION(gta_context_handle_t, gta_context_open,
     gta_context_handle_t h_ctx = GTA_HANDLE_INVALID;
     context_object_t * p_ctx_obj = NULL_PTR;
 
-    struct provider_list_item_t * p_provider_list_item;
-    struct profile_list_item_t * p_profile_list_item;
-    gta_errinfo_t errinfo = GTA_ERROR_INTERNAL_ERROR;
+    struct provider_list_item_t * p_provider_list_item = NULL;
+    const struct profile_list_item_t * p_profile_list_item = NULL;
 
     p_inst_obj = check_instance_handle(h_inst, p_errinfo);
 
@@ -809,42 +809,42 @@ GTA_DEFINE_FUNCTION(gta_context_handle_t, gta_context_open,
         /* Check personality_name and profile */
         if ((NULL != personality_name) && (NULL != profile)) {
             /* Find provider holding the personality in question */
-            p_provider_list_item = find_personality(h_inst, personality_name,
-                &errinfo);
-            if (NULL != p_provider_list_item) {
-                /* Check whether the profile in question is supported by
-                 * provider */
-                p_profile_list_item = list_find(
-                    (struct list_t *)(p_inst_obj->p_profile_list),
-                    profile, profile_name_cmp);
-                if ((NULL != p_profile_list_item) && (p_provider_list_item == p_profile_list_item->p_provider)) {
-                    h_prectx = alloc_handle(GTA_HANDLE_TYPE_CONTEXT, p_inst_obj,
-                        (void **)(&p_ctx_obj), p_errinfo);
-                    p_ctx_obj->p_provider = p_provider_list_item;
-                    if (NULL != p_provider_list_item->function_list->pf_gta_provider_context_open) {
-                        if (p_provider_list_item->function_list->pf_gta_provider_context_open(h_prectx,
-                            personality_name, profile, &(p_ctx_obj->p_context_params), p_errinfo)) {
-                            h_ctx = h_prectx;
+            if (find_personality(h_inst, personality_name, &p_provider_list_item, p_errinfo)) {
+                if (NULL != p_provider_list_item) {
+                    /* Check whether the profile in question is supported by
+                    * provider */
+                    p_profile_list_item = list_find(
+                        (struct list_t *)(p_inst_obj->p_profile_list),
+                        profile, profile_name_cmp);
+                    if ((NULL != p_profile_list_item) && (p_provider_list_item == p_profile_list_item->p_provider)) {
+                        h_prectx = alloc_handle(GTA_HANDLE_TYPE_CONTEXT, p_inst_obj,
+                            (void **)(&p_ctx_obj), p_errinfo);
+                        p_ctx_obj->p_provider = p_provider_list_item;
+                        if (NULL != p_provider_list_item->function_list->pf_gta_provider_context_open) {
+                            if (p_provider_list_item->function_list->pf_gta_provider_context_open(h_prectx,
+                                personality_name, profile, &(p_ctx_obj->p_context_params), p_errinfo)) {
+                                h_ctx = h_prectx;
+                            }
+                            else {
+                                /* tear down preliminary context */
+                                gta_errinfo_t err;
+                                /* error returned fromfree_handle must not hide
+                                * error returned by context_open .*/
+                                free_handle(h_prectx, &err);
+                            }
                         }
                         else {
-                            /* tear down preliminary context */
-                            gta_errinfo_t err;
-                            /* error returned fromfree_handle must not hide
-                             * error returned by context_open .*/
-                            free_handle(h_prectx, &err);
+                            *p_errinfo = GTA_ERROR_PROVIDER_INVALID;
                         }
                     }
                     else {
-                        *p_errinfo = GTA_ERROR_PROVIDER_INVALID;
+                        *p_errinfo = GTA_ERROR_PROFILE_UNSUPPORTED;
                     }
                 }
                 else {
-                    *p_errinfo = GTA_ERROR_PROFILE_UNSUPPORTED;
+                    /* todo(thomas.zeschg): error code? */
+                    *p_errinfo = GTA_ERROR_INVALID_PARAMETER;
                 }
-            }
-            else {
-                /* todo(thomas.zeschg): error code? */
-                *p_errinfo = GTA_ERROR_INVALID_PARAMETER;
             }
         }
         else {
@@ -2399,11 +2399,14 @@ personality_deploy_create(
             && (NULL != check_access_policy_handle(auth_use, true, p_errinfo))) {
 
             /* Check for potential name clashes */
-            if (NULL == find_personality(h_inst, personality_name, p_errinfo)) {
-                p_provider = select_provider_by_profile(h_inst, profile, p_errinfo);
-            }
-            else {
-                *p_errinfo = GTA_ERROR_NAME_ALREADY_EXISTS;
+            struct provider_list_item_t * p_provider_list_item = NULL;
+            if (find_personality(h_inst, personality_name, &p_provider_list_item, p_errinfo)) {
+                if (NULL == p_provider_list_item) {
+                    p_provider = select_provider_by_profile(h_inst, profile, p_errinfo);
+                }
+                else {
+                    *p_errinfo = GTA_ERROR_NAME_ALREADY_EXISTS;
+                }
             }
         }
         else {
@@ -2726,7 +2729,7 @@ GTA_DEFINE_FUNCTION(bool, gta_personality_attributes_enumerate, (
     instance_object_t * p_inst_obj = NULL;
     struct instance_provider_object_t * p_instance_provider_obj = NULL_PTR;
     gta_instance_handle_t h_inst_provider = NULL;
-    struct provider_list_item_t * p_provider_list_item;
+    struct provider_list_item_t * p_provider_list_item = NULL;
     gta_errinfo_t errinfo = GTA_ERROR_INTERNAL_ERROR;
     bool ret = false;
 
@@ -2738,9 +2741,9 @@ GTA_DEFINE_FUNCTION(bool, gta_personality_attributes_enumerate, (
 
     if (NULL != p_inst_obj) {
         /* Find provider holding the personality in question */
-        p_provider_list_item = find_personality(h_inst, personality_name,
-            &errinfo);
-        if (NULL != p_provider_list_item) {
+        if ((find_personality(h_inst, personality_name,
+            &p_provider_list_item, &errinfo)) && (NULL != p_provider_list_item)) {
+
             h_inst_provider = alloc_handle(GTA_HANDLE_TYPE_INSTANCE_PROVIDER,
                 p_inst_obj, (void **)(&p_instance_provider_obj), p_errinfo);
             if (GTA_HANDLE_INVALID != h_inst_provider) {
@@ -3817,16 +3820,19 @@ static void ostream_to_buf_init
     memset(buf, 0x00, buf_size);
 }
 
-/* Auxiliary function to search a personality in the currently registered
- * providers. Returns p_provider_list_item if found, otherwise NULL */
-static struct provider_list_item_t *
+/*
+ * Auxiliary function to search a personality in the currently registered
+ * providers. Returns true if no error occurs, otherwise false. The
+ * parameter p_provider_list_item contains the personality in case it has
+ * been found, otherwise NULL.
+ */
+static bool
 find_personality(gta_instance_handle_t h_inst,
     const gta_personality_name_t personality_name,
+    struct provider_list_item_t ** p_provider_list_item,
     gta_errinfo_t * p_errinfo)
 {
     struct framework_enum_object_t * p_framework_enum_obj = NULL_PTR;
-    struct provider_list_item_t * p_provider_list_item = NULL;
-
     gtaio_ostream_t o_idtype = { 0 };
     o_idtype.write = (gtaio_stream_write_t)ostream_null_write;
     o_idtype.finish = (gtaio_stream_finish_t)ostream_finish;
@@ -3836,6 +3842,7 @@ find_personality(gta_instance_handle_t h_inst,
     bool b_idloop = true;
     bool b_persloop = true;
     gta_enum_handle_t h_idenum = GTA_HANDLE_ENUM_FIRST;
+    bool b_ret = true;
 
     /* loop over all identifier */
     while (b_idloop) {
@@ -3857,12 +3864,13 @@ find_personality(gta_instance_handle_t h_inst,
                          * provider holding the personality */
                         p_framework_enum_obj = check_framework_enum_handle(
                             h_persenum, p_errinfo);
-                        if (NULL != p_framework_enum_obj) {
-                            p_provider_list_item = p_framework_enum_obj->p_provider;
+                        if ((NULL != p_framework_enum_obj) && (NULL != p_provider_list_item)) {
+                            *p_provider_list_item = p_framework_enum_obj->p_provider;
                         }
                         else {
                             /* todo(thomas.zeschg): how to handle an error
                              * here? */
+                            b_ret = false;
                         }
 
                         /* Even if we found the personality, we loop until the
@@ -3874,6 +3882,7 @@ find_personality(gta_instance_handle_t h_inst,
                     if (GTA_ERROR_ENUM_NO_MORE_ITEMS != errinfo) {
                         /* Error in enumeration */
                         *p_errinfo = errinfo;
+                        b_ret = false;
                     }
                 }
             }
@@ -3883,10 +3892,11 @@ find_personality(gta_instance_handle_t h_inst,
             if (GTA_ERROR_ENUM_NO_MORE_ITEMS != errinfo) {
                 /* Error in enumeration */
                 *p_errinfo = errinfo;
+                b_ret = false;
             }
         }
     }
-    return p_provider_list_item;
+    return b_ret;
 }
 
 /*

--- a/src/gta_api.c
+++ b/src/gta_api.c
@@ -2763,9 +2763,6 @@ GTA_DEFINE_FUNCTION(bool, gta_personality_attributes_enumerate, (
             *p_errinfo = GTA_ERROR_ITEM_NOT_FOUND;
         }
     }
-    else {
-        *p_errinfo = GTA_ERROR_INVALID_PARAMETER;
-    }
     return ret;
 }
 

--- a/test/test_framework.c
+++ b/test/test_framework.c
@@ -1214,6 +1214,7 @@ test_gta_personality_enumerate_application(void ** state)
     struct framework_test_params_t * framework_test_params = (struct framework_test_params_t *)(*state);
     gta_errinfo_t errinfo = 0;
     gtaio_ostream_t personality_name = { 0 };
+    bool b_loop = true;
     gta_enum_handle_t h_enum = GTA_HANDLE_ENUM_FIRST;
 
     assert_false(gta_personality_enumerate_application(framework_test_params->h_inst,
@@ -1270,6 +1271,19 @@ test_gta_personality_enumerate_application(void ** state)
         &personality_name,
         &errinfo));
     assert_int_equal(errinfo, GTA_ERROR_INVALID_PARAMETER);
+
+    while(b_loop) {
+        if (!gta_personality_enumerate_application(framework_test_params->h_inst,
+            "application",
+            &h_enum,
+            1,
+            &personality_name,
+            &errinfo)) {
+
+            assert_int_equal(GTA_ERROR_ENUM_NO_MORE_ITEMS, errinfo);
+            b_loop = false;
+        }
+    }
 }
 
 static void

--- a/test/test_framework.c
+++ b/test/test_framework.c
@@ -1091,7 +1091,21 @@ test_gta_context_auth_get_challenge(void ** state)
 static void
 test_gta_context_auth_set_random(void ** state)
 {
-    /* todo */
+    struct framework_test_params_t * framework_test_params = (struct framework_test_params_t *)(*state);
+    gta_errinfo_t errinfo = 0;
+    gtaio_istream_t random = { 0 };
+
+    assert_false(gta_context_auth_set_random(NULL, NULL, NULL));
+
+    assert_false(gta_context_auth_set_random(NULL, &random, &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_HANDLE_INVALID);
+
+    assert_false(gta_context_auth_set_random(framework_test_params->h_ctx, NULL, &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_INVALID_PARAMETER);
+
+    errinfo = 0;
+    assert_true(gta_context_auth_set_random(framework_test_params->h_ctx, &random, &errinfo));
+    assert_int_equal(errinfo, 0);
 }
 
 static void

--- a/test/test_framework.c
+++ b/test/test_framework.c
@@ -1071,7 +1071,21 @@ test_gta_context_auth_set_access_token(void ** state)
 static void
 test_gta_context_auth_get_challenge(void ** state)
 {
-    /* todo */
+    struct framework_test_params_t * framework_test_params = (struct framework_test_params_t *)(*state);
+    gta_errinfo_t errinfo = 0;
+    gtaio_ostream_t challenge = { 0 };
+
+    assert_false(gta_context_auth_get_challenge(NULL, NULL, NULL));
+
+    assert_false(gta_context_auth_get_challenge(NULL, &challenge, &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_HANDLE_INVALID);
+
+    assert_false(gta_context_auth_get_challenge(framework_test_params->h_ctx, NULL, &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_INVALID_PARAMETER);
+
+    errinfo = 0;
+    assert_true(gta_context_auth_get_challenge(framework_test_params->h_ctx, &challenge, &errinfo));
+    assert_int_equal(errinfo, 0);
 }
 
 static void

--- a/test/test_framework.c
+++ b/test/test_framework.c
@@ -1502,6 +1502,93 @@ test_gta_personality_activate_attribute(void ** state)
 }
 
 static void
+test_gta_personality_attributes_enumerate(void ** state)
+{
+    struct framework_test_params_t * framework_test_params = (struct framework_test_params_t *)(*state);
+    gta_errinfo_t errinfo = 0;
+    gtaio_ostream_t attribute_type = { 0 };
+    gtaio_ostream_t attribute_name = { 0 };
+    bool b_loop = true;
+    gta_enum_handle_t h_enum = GTA_HANDLE_ENUM_FIRST;
+
+    assert_false(gta_personality_attributes_enumerate(framework_test_params->h_inst,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL));
+
+    assert_false(gta_personality_attributes_enumerate(framework_test_params->h_inst,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_INVALID_PARAMETER);
+
+    assert_false(gta_personality_attributes_enumerate(NULL,
+        "personality",
+        &h_enum,
+        &attribute_type,
+        &attribute_name,
+        &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_HANDLE_INVALID);
+
+    assert_false(gta_personality_attributes_enumerate(framework_test_params->h_inst,
+        NULL,
+        &h_enum,
+        &attribute_type,
+        &attribute_name,
+        &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_INVALID_PARAMETER);
+
+    assert_false(gta_personality_attributes_enumerate(framework_test_params->h_inst,
+        "personality",
+        NULL,
+        &attribute_type,
+        &attribute_name,
+        &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_INVALID_PARAMETER);
+
+    assert_false(gta_personality_attributes_enumerate(framework_test_params->h_inst,
+        "personality",
+        &h_enum,
+        NULL,
+        &attribute_name,
+        &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_INVALID_PARAMETER);
+
+    assert_false(gta_personality_attributes_enumerate(framework_test_params->h_inst,
+        "personality",
+        &h_enum,
+        &attribute_type,
+        NULL,
+        &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_INVALID_PARAMETER);
+
+    assert_false(gta_personality_attributes_enumerate(framework_test_params->h_inst,
+        "personality",
+        &h_enum,
+        &attribute_type,
+        &attribute_name,
+        &errinfo));
+    assert_int_equal(errinfo, GTA_ERROR_ITEM_NOT_FOUND);
+
+    while(b_loop) {
+        if (!gta_personality_attributes_enumerate(framework_test_params->h_inst,
+            "personality1",
+            &h_enum,
+            &attribute_type,
+            &attribute_name,
+            &errinfo)) {
+
+            assert_int_equal(GTA_ERROR_ENUM_NO_MORE_ITEMS, errinfo);
+            b_loop = false;
+        }
+    }
+}
+
+static void
 test_gta_seal_data(void ** state)
 {
     struct framework_test_params_t * framework_test_params = (struct framework_test_params_t *)(*state);
@@ -1828,6 +1915,7 @@ int ts_framework(void)
         cmocka_unit_test(test_gta_personality_remove_attribute),
         cmocka_unit_test(test_gta_personality_deactivate_attribute),
         cmocka_unit_test(test_gta_personality_activate_attribute),
+        cmocka_unit_test(test_gta_personality_attributes_enumerate),
         cmocka_unit_test(test_gta_seal_data),
         cmocka_unit_test(test_gta_unseal_data),
         cmocka_unit_test(test_gta_verify),

--- a/test/unittest_gta_provider/unittest_gta_provider.c
+++ b/test/unittest_gta_provider/unittest_gta_provider.c
@@ -140,13 +140,7 @@ GTA_DEFINE_FUNCTION(bool, unittest_provider_gta_context_auth_get_challenge,
     gta_errinfo_t * p_errinfo
     ))
 {
-    bool ret = false;
-
-    *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
-
-    /* ... */
-
-    return ret;
+    return true;
 }
 
 

--- a/test/unittest_gta_provider/unittest_gta_provider.c
+++ b/test/unittest_gta_provider/unittest_gta_provider.c
@@ -409,13 +409,26 @@ GTA_DEFINE_FUNCTION(bool, unittest_provider_gta_personality_enumerate_applicatio
     gta_errinfo_t * p_errinfo
     ))
 {
-    bool ret = false;
+    bool b_ret = false;
 
-    *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
+    /* hardcoded behaviour for framework tests */
+    #define GTA_HANDLE_ENUM_1 ((gta_context_handle_t)-2)
+    #define GTA_HANDLE_ENUM_2 ((gta_context_handle_t)-3)
 
-    /* ... */
+    if (GTA_HANDLE_ENUM_FIRST == *ph_enum) {
+        /* We don't write the output in the framework tests */
+        *ph_enum = GTA_HANDLE_ENUM_1;
+        b_ret = true;
+    } else if (GTA_HANDLE_ENUM_1 == *ph_enum) {
+        /* We don't write the output in the framework tests */
+        *ph_enum = GTA_HANDLE_ENUM_2;
+        b_ret = true;
+    } else if (GTA_HANDLE_ENUM_2 == *ph_enum) {
+        *ph_enum = GTA_HANDLE_INVALID;
+        *p_errinfo = GTA_ERROR_ENUM_NO_MORE_ITEMS;
+    }
 
-    return ret;
+    return b_ret;
 }
 
 

--- a/test/unittest_gta_provider/unittest_gta_provider.c
+++ b/test/unittest_gta_provider/unittest_gta_provider.c
@@ -612,13 +612,26 @@ GTA_DEFINE_FUNCTION(bool, unittest_provider_gta_personality_attributes_enumerate
     gta_errinfo_t * p_errinfo
     ))
 {
-    bool ret = false;
+    bool b_ret = false;
 
-    *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
+    /* hardcoded behaviour for framework tests */
+    #define GTA_HANDLE_ENUM_1 ((gta_context_handle_t)-2)
+    #define GTA_HANDLE_ENUM_2 ((gta_context_handle_t)-3)
 
-    /* ... */
+    if (GTA_HANDLE_ENUM_FIRST == *ph_enum) {
+        /* We don't write the output in the framework tests */
+        *ph_enum = GTA_HANDLE_ENUM_1;
+        b_ret = true;
+    } else if (GTA_HANDLE_ENUM_1 == *ph_enum) {
+        /* We don't write the output in the framework tests */
+        *ph_enum = GTA_HANDLE_ENUM_2;
+        b_ret = true;
+    } else if (GTA_HANDLE_ENUM_2 == *ph_enum) {
+        *ph_enum = GTA_HANDLE_INVALID;
+        *p_errinfo = GTA_ERROR_ENUM_NO_MORE_ITEMS;
+    }
 
-    return ret;
+    return b_ret;
 }
 
 

--- a/test/unittest_gta_provider/unittest_gta_provider.c
+++ b/test/unittest_gta_provider/unittest_gta_provider.c
@@ -151,13 +151,7 @@ GTA_DEFINE_FUNCTION(bool, unittest_provider_gta_context_auth_set_random,
     gta_errinfo_t * p_errinfo
     ))
 {
-    bool ret = false;
-
-    *p_errinfo = GTA_ERROR_INTERNAL_ERROR;
-
-    /* ... */
-
-    return ret;
+    return true;
 }
 
 


### PR DESCRIPTION
* fix: find_personality helper function
  Now it is possible to differentiate between an error in the function (e.g., enumeration) and a personality not found.
* fix: error code in gta_personality_attributes_enumerate
* test: add test for gta_personality_attributes_enumerate
* test: add positive test for gta_personality_enumerate_application
* test: add test for gta_context_auth_get_challenge
* test: add test for gta_context_auth_set_random