### PR TITLE
chore: improve pre-commit hook

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -7,8 +7,7 @@
 # Select files to format
 files=$(git diff --cached --name-only | grep -E '\.(c|h)$')
 [ -z "$files" ] && exit 0
-# Format all selected files
-clang-format -i $files
-# Add back the modified files to staging
-echo "$files" | xargs git add
+# Format all relevant lines of selected files
+diff=$(git diff --cached -U0 --no-color $files)
+echo "$diff" | clang-format-diff -p1 -i
 exit 0


### PR DESCRIPTION
<!--
Thank you for your contribution! ❤️

To help us maintain high standards of quality and consistency, please follow our Contribution Guidelines.
-->

## Motivation and Proposed Changes

<!-- Please describe your motivation and explain the changes. If applicable, link relevant issues. -->
The current pre-commit hook does not work with partial staging. If e.g. only a part of a file is set for staging (using `git add -p`), the pre-commit hook formats the whole file and adds the whole file back to staging.

This PR improves the pre-commit hook so that it works well with partial staging and formats only the already staged lines.

## Checklist

Before requesting a review, please ensure the following:

- [x] Commit history is clean and meaningful
- [x] License and copyright headers are present and up to date
- [x] SonarCloud report has been reviewed; no obvious improvements possible with reasonable effort
- [ ] Documentation has been updated or extended (if applicable)
- [ ] If this PR affects other repositories in the namespace, an issue has been opened and linked accordingly
